### PR TITLE
delete lease_time from response to DHCPINFORM

### DIFF
--- a/openIPAM/openipam/dhcp_server.py
+++ b/openIPAM/openipam/dhcp_server.py
@@ -588,6 +588,9 @@ def db_consumer( dbq, send_packet ):
 			
 			self.assign_dhcp_options( options=opt_vals, requested=requested_options, packet=ack )
 
+			ack.DeleteOption("yiaddr")
+			ack.DeleteOption("lease_time")
+
 			# send an ack
 			self.SendPacket( ack )
 		


### PR DESCRIPTION
DHCPINFORM responses (DHCPACK) should not contain lease_time or yiaddr.  Delete them right before send.